### PR TITLE
Add to the 1.12.2 guide that onDemandAnimatedTextures needs to be disabled in CensoredASM's config file and remove the Naughtirium part.

### DIFF
--- a/mods-n-stuff/1.12.2.md
+++ b/mods-n-stuff/1.12.2.md
@@ -5,10 +5,10 @@
 | Mod | Notes | Client/Server |
 |:---:|:---:|:---:|
 | Alfheim Lighting Engine | - | Server |
-| CensoredASM | - | Both |
+| CensoredASM | Disable onDemandAnimatedTextures in the mod's configuration file, otherwise it does not fully work with Nothirium | Both |
 | Entity Culling | There are 2 mods going by that name, the one I'd recommend is by tr7zw. There is an edge case where Entity Culling can crash the game. See [this](https://github.com/CaffeineMC/sodium/issues/2985) for more info | Client |
 | Fixeroo | - | Both |
-| Nothirium | If you're using CensoredASM, install Naughthirium as well, otherwise animations won't work. **Not compatible with Celeritas, you have to use one or the other** | Client |
+| Nothirium | **Not compatible with Celeritas, you have to use one or the other** | Client |
 | StellarCore | Disable `NBTTagImprovements`, `ParallelModelLoader`, `ResourceExistStateCache` and `ResourceLocationCanonicalization` as CensoredASM and VintageFix already have similar optimizations. | Both |
 | UniversalTweaks | - | Both |
 | VintageFix | - | Both |


### PR DESCRIPTION
Hi, thought i'd make this PR, as I found out that Naughtirium is not nessecary to have CensoredASM and Nothirium work fully together, you can just disable a thing in the config file.

But having Naughtirium allows for both mods to work without config changes, so I understand why the guide is the way it is right now.

My reasoning for this PR is that with the new line I added, there is no need for an extra mod, thus the mod amount is reduced.

But it is totally up to you if you want this merged or not.