### PR TITLE
Fix the spelling mistakes in additions.md

### DIFF
--- a/mods-n-stuff/additions.md
+++ b/mods-n-stuff/additions.md
@@ -19,7 +19,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Gnetum | Distributes HUD updates over multiple frames which improves performance | NeoForge | Client |
 | Immersive Optimization | Improves TPS, but may differ from Vanilla slightly | Fabric, NeoForge | Server |
 | Ixeris | Offloads event polling to a separate thread, potentially improving FPS | NeoForge | Client |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on mulitplayer | Fabric, Forge, NeoForge | Both |
+| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge, NeoForge | Both |
 | MapMipMapMod | Improves mipmapping of maps in item frames | Fabric | Client |
 | Mobtimizations | Modifies Entity behavior to improve performance. May differ from Vanilla slightly | Fabric, NeoForge | Server |
 | Not Enough Recipe Book | Removes the recipe book which can help performance in some cases. Reduces redundancy with item viewers such as EMI | Fabric, NeoForge | Both |
@@ -47,7 +47,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Gnetum | Distributes HUD updates over multiple frames which improves performance | Forge | Client |
 | Immersive Optimization | Improves TPS, but may differ from Vanilla slightly | Fabric, Forge | Server |
 | Ixeris | Offloads event polling to a separate thread, potentially improving FPS | NeoForge | Client |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on mulitplayer | Fabric, Forge | Both |
+| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
 | Lazyyyyy | Can improve loading times in bigger modpacks | Forge | Both |
 | MapMipMapMod | Improves mipmapping of maps in item frames | Fabric | Client |
 | Mobtimizations | Modifies Entity behavior to improve performance. May differ from Vanilla slightly | Fabric, Forge | Server |
@@ -72,7 +72,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Clumps | Clumps XP Orbs together, reducing lag | Fabric, Forge | Server |
 | Debugify/Debugify Reforged | Fixes various bugs | Fabric, Forge | Both |
 | Icterine | Optimizes the advancement checking system | Fabric, Forge | Server |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on mulitplayer | Fabric, Forge | Both |
+| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
 | Mobtimizations | Modifies Entity behavior to improve performance. May differ from Vanilla slightly | Fabric, Forge | Server |
 | Not Enough Recipe Book | Removes the recipe book which can help performance in some cases. Reduces redundancy with item viewers such as EMI | Fabric, Forge | Both |
 | SerializationIsBad | Fixes the BleedingPipe/ObjectInputStream vulnerability | Forge | Both |
@@ -92,7 +92,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Clumps | Clumps XP Orbs together, reducing lag | Fabric, Forge | Server |
 | Debugify/Modern Debugify | Fixes various bugs. Modern Debugify needs to have MC-147605 disabled if you're using JEI | Fabric, Forge | Both |
 | Icterine | Optimizes the advancement checking system | Fabric, Forge | Server |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on mulitplayer | Fabric, Forge | Both |
+| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
 | Mobtimizations | Modifies Entity behavior to improve performance. May differ from Vanilla slightly | Fabric, Forge | Server |
 | Not Enough Recipe Book | Removes the recipe book which can help performance in some cases. Reduces redundancy with item viewers such as EMI | Fabric, Forge | Both |
 | SerializationIsBad | Fixes the BleedingPipe/ObjectInputStream vulnerability | Forge | Both |
@@ -110,7 +110,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 |:---:|:---:|:---:|:---:|
 | Alternate Current | Can improve performance with lots of redstone contraptions around | Fabric, Forge | Server |
 | Clumps | Clumps XP Orbs together, reducing lag | Fabric, Forge | Both |
-| Krypton | Improves the network stack, may be helpful on mulitplayer | Fabric | Both |
+| Krypton | Improves the network stack, may be helpful on multiplayer | Fabric | Both |
 | SerializationIsBad | Fixes the BleedingPipe/ObjectInputStream vulnerability | Forge | Both |
 | Smooth Boot | Modifies CPU scheduling to improve loading times | Fabric | Both |
 | Structure Layout Optimizer | Improves structure generation speed, helpful in packs with lots of structures | Fabric, Forge | Server |


### PR DESCRIPTION
This is a simple PR that fixes the "mulitplayer" spelling mistake seen in Krypton's descriptions in additions.md