### PR TITLE
Add notes regarding latest version of ftb academy

### DIFF
--- a/modpack-specific/packs-1.12.2.md
+++ b/modpack-specific/packs-1.12.2.md
@@ -155,6 +155,7 @@ Known issues: Doesn't work on latest Cleanroom (0.3.26), use 0.3.24 for now.
 6. Make sure you have all of [these mods](/mods-n-stuff/1.12.2.md) installed and configured accordingly
 
 Known issues: None (yet?)
+Note: In the latest version of FTB Academy (1.4.1) Dynamic Trees and Dynamic Trees - Traverse will not be in the mods list due to them being deleted as of version 1.2. Also do not forget to remove FTB Auxilium otherwise your game will crash om startup.
 
 </details>
 

--- a/modpack-specific/packs-1.12.2.md
+++ b/modpack-specific/packs-1.12.2.md
@@ -156,7 +156,7 @@ Known issues: Doesn't work on latest Cleanroom (0.3.26), use 0.3.24 for now.
 
 Known issues: None (yet?)
 
-Note: In the latest version of FTB Academy (1.4.1) Dynamic Trees and Dynamic Trees - Traverse will not be in the mods list due to them being deleted as of version 1.2. Also do not forget to remove FTB Auxilium otherwise your game will crash om startup.
+Note: In the latest version of FTB Academy (1.4.1) Dynamic Trees and Dynamic Trees - Traverse are not included in the mods list due to them being deleted as of version 1.2. Also do not forget to remove FTB Auxilium otherwise your game will crash om startup.
 
 </details>
 

--- a/modpack-specific/packs-1.12.2.md
+++ b/modpack-specific/packs-1.12.2.md
@@ -155,6 +155,7 @@ Known issues: Doesn't work on latest Cleanroom (0.3.26), use 0.3.24 for now.
 6. Make sure you have all of [these mods](/mods-n-stuff/1.12.2.md) installed and configured accordingly
 
 Known issues: None (yet?)
+
 Note: In the latest version of FTB Academy (1.4.1) Dynamic Trees and Dynamic Trees - Traverse will not be in the mods list due to them being deleted as of version 1.2. Also do not forget to remove FTB Auxilium otherwise your game will crash om startup.
 
 </details>

--- a/modpack-specific/packs-1.12.2.md
+++ b/modpack-specific/packs-1.12.2.md
@@ -156,7 +156,7 @@ Known issues: Doesn't work on latest Cleanroom (0.3.26), use 0.3.24 for now.
 
 Known issues: None (yet?)
 
-Note: In the latest version of FTB Academy (1.4.1) Dynamic Trees and Dynamic Trees - Traverse are not included in the mods list due to them being deleted as of version 1.2. Also do not forget to remove FTB Auxilium otherwise your game will crash om startup.
+**Note:** In the latest version of FTB Academy (1.4.1) Dynamic Trees and Dynamic Trees - Traverse are not included in the mods list due to them being deleted as of version 1.2. Also do not forget to remove FTB Auxilium otherwise your game will crash om startup.
 
 </details>
 


### PR DESCRIPTION
Following the instructions confused me a bit due to the fact that they were made for the curseforge release of ftb academy while i had downlaoded 1.4.1 through prism launcher. This just clarifies some things and fixes a crash that got me confused for a while.