### PR TITLE
Update ZenUtils for Cleanroom compatibility in Divine Journey 2

### DIFF
--- a/modpack-specific/packs-1.12.2.md
+++ b/modpack-specific/packs-1.12.2.md
@@ -94,7 +94,7 @@ Known issues: None (yet?)
 2. Move the pack to Cleanroom Loader
    - **(Prism/MultiMC)** - Download the latest [Cleanroom Loader MMC instance](https://download.cleanroommc.com) and copy the `minecraft` (or `.minecraft`) folder from the Divine Journey 2 instance to it.
    - **(CurseForge/Modrinth/ATLauncher/GDLauncher)** - Install the Cleanroom Relauncher mod
-3. Update JEI Utilities, Recurrent Complex, Universal Tweaks, and VintageFix
+3. Update JEI Utilities, Recurrent Complex, Universal Tweaks, ZenUtils and VintageFix
 4. Remove Clumps, ConfigAnytime, FermiumASM, Just Enough Items, MixinBooter, NotEnoughIDs and Spark
 5. Install Fugue, Had Enough Items, Roughly Enough IDs, Flare and Scalar Legacy
 6. Make sure you have all of [these mods](/mods-n-stuff/1.12.2.md) installed and configured accordingly


### PR DESCRIPTION
## Summary

- Added ZenUtils to the list of mods that should be updated.
- Clarified the Divine Journey 2 migration instructions for Cleanroom.

## Reason

The ZenUtils version bundled with the modpack can crash during startup on Cleanroom 0.6.x with an `IllegalAccessError` in `ZenMixin`.

## Verification

- Minecraft 1.12.2
- Divine Journey 2
- Cleanroom 0.6.8-alpha
- ZenUtils 1.28.0