### PR TITLE
Update KryptonFNP name to newest name

### DIFF
--- a/mods-n-stuff/additions.md
+++ b/mods-n-stuff/additions.md
@@ -20,7 +20,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Gnetum | Distributes HUD updates over multiple frames which improves performance | NeoForge | Client |
 | Immersive Optimization | Improves TPS, but may differ from Vanilla slightly | Fabric, NeoForge | Server |
 | Ixeris | Offloads event polling to a separate thread, potentially improving FPS | NeoForge | Client |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge, NeoForge | Both |
+| Krypton/Krypton Reno | Improves the network stack, may be helpful on multiplayer | Fabric, Forge, NeoForge | Both |
 | MapMipMapMod | Improves mipmapping of maps in item frames | Fabric | Client |
 | Not Enough Recipe Book | Removes the recipe book which can help performance in some cases. Reduces redundancy with item viewers such as EMI | Fabric, NeoForge | Both |
 | Structure Layout Optimizer | Improves structure generation speed, helpful in packs with lots of structures | Fabric, NeoForge | Server |
@@ -48,7 +48,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Gnetum | Distributes HUD updates over multiple frames which improves performance | Forge | Client |
 | Immersive Optimization | Improves TPS, but may differ from Vanilla slightly | Fabric, Forge | Server |
 | Ixeris | Offloads event polling to a separate thread, potentially improving FPS | NeoForge | Client |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
+| Krypton/Krypton Reno | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
 | Lazyyyyy | Can improve loading times in bigger modpacks | Forge | Both |
 | MapMipMapMod | Improves mipmapping of maps in item frames | Fabric | Client |
 | Mobtimizations | Modifies Entity behavior to improve performance. May differ from Vanilla slightly | Fabric, Forge | Server |
@@ -74,7 +74,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Clumps | Clumps XP Orbs together, reducing lag | Fabric, Forge | Server |
 | Debugify/Debugify Reforged | Fixes various bugs | Fabric, Forge | Both |
 | Icterine | Optimizes the advancement checking system | Fabric, Forge | Server |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
+| Krypton/Krypton Reno | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
 | Mobtimizations | Modifies Entity behavior to improve performance. May differ from Vanilla slightly | Fabric, Forge | Server |
 | Not Enough Recipe Book | Removes the recipe book which can help performance in some cases. Reduces redundancy with item viewers such as EMI | Fabric, Forge | Both |
 | SerializationIsBad | Fixes the BleedingPipe/ObjectInputStream vulnerability | Forge | Both |
@@ -95,7 +95,7 @@ This doesn't mean you should just install all of them. Only use the ones you nee
 | Clumps | Clumps XP Orbs together, reducing lag | Fabric, Forge | Server |
 | Debugify/Modern Debugify | Fixes various bugs. Modern Debugify needs to have MC-147605 disabled if you're using JEI | Fabric, Forge | Both |
 | Icterine | Optimizes the advancement checking system | Fabric, Forge | Server |
-| Krypton/Krypton FNP | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
+| Krypton/Krypton Reno | Improves the network stack, may be helpful on multiplayer | Fabric, Forge | Both |
 | Mobtimizations | Modifies Entity behavior to improve performance. May differ from Vanilla slightly | Fabric, Forge | Server |
 | Not Enough Recipe Book | Removes the recipe book which can help performance in some cases. Reduces redundancy with item viewers such as EMI | Fabric, Forge | Both |
 | SerializationIsBad | Fixes the BleedingPipe/ObjectInputStream vulnerability | Forge | Both |

--- a/mods-n-stuff/not-recommended.md
+++ b/mods-n-stuff/not-recommended.md
@@ -14,7 +14,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better Biome Reblend | Redundant with Sodium |
 | Better Chunk Loading | May cause issues [[1]](https://github.com/FiniteReality/embeddium/wiki/Compatibility#other-known-incompatibilities) |
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
-| Chunk Sending | Redundant with Krypton/KryptonReno |
+| Chunk Sending | Redundant with Krypton/Krypton Reno |
 | CLab | AI-Slop. Redundant with Entity Culling |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Cull Leaves | Redundant with More Culling |
@@ -31,7 +31,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | FeyTweaks | Mostly redundant with ImmediatelyFast |
 | FPS Boost | Fake mod, doesn't provide any performance improvements |
 | GPUBooster/GPUTape | Doesn't actually fix VRAM leaks |
-| KryptonFoxified | Redundant with KryptonReno |
+| KryptonFoxified | Redundant with Krypton Reno |
 | Ksyxis | Removes spawn chunks |
 | lazy-language-loader | Redundant with Language Reload |
 | Methane | Disables light calculations, breaks Vanilla parity, incompatible with ScalableLux |
@@ -69,7 +69,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
 | Brute force render culling | Visual bugs |
 | Canary | Redundant with Radium |
-| Chunk Sending | Redundant with Krypton/KryptonReno |
+| Chunk Sending | Redundant with Krypton/Krypton Reno |
 | CLab | AI-Slop. Redundant with Entity Culling |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Concurrent Chunk Management Engine Forge (C2MEF) | No different than using C2ME via Synitra Connector |
@@ -133,7 +133,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
 | Brute force render culling | Visual bugs |
 | Canary | Redundant with Radium |
-| Chunk Sending | Redundant with Krypton/KryptonReno |
+| Chunk Sending | Redundant with Krypton/Krypton Reno |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Cull Clouds | Negligible performance improvement |
 | Cull Leaves | Redundant with More Culling |
@@ -164,7 +164,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | OptiLeaves | Redundant with CullLessLeaves Reforged |
 | OptiPainting | Redundant with FastPaintings |
 | Out Of Sight | Redundant with Entity Culling |
-| Pluto | Redundant with KryptonReno |
+| Pluto | Redundant with Krypton Reno |
 | Radon | Redundant with Starlight |
 | Recipe Essentials | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Redirector [Modern] | Compatibility issues, negligible performance improvement |
@@ -191,7 +191,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better Chunk Loading | May cause issues [[1]](https://github.com/FiniteReality/embeddium/wiki/Compatibility#other-known-incompatibilities) |
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
 | Brute force render culling | Visual bugs |
-| Chunk Sending | Redundant with Krypton/KryptonReno |
+| Chunk Sending | Redundant with Krypton/Krypton Reno |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Cull Clouds | Negligible performance improvement |
 | Cull Leaves | Redundant with More Culling |
@@ -218,7 +218,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | OptiFine | [Various reasons](opti-not-so-fine.md) |
 | OptiLeaves | Redundant with CullLessLeaves Reforged |
 | Out Of Sight | Redundant with Entity Culling |
-| Pluto | Redundant with KryptonReno |
+| Pluto | Redundant with Krypton Reno |
 | Radon | Redundant with Starlight |
 | Recipe Cache | Redundant with FastFurnace, FastWorkench and FastSuite |
 | Redirector [Modern] | Compatibility issues, negligible performance improvement |

--- a/mods-n-stuff/not-recommended.md
+++ b/mods-n-stuff/not-recommended.md
@@ -14,7 +14,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better Biome Reblend | Redundant with Sodium |
 | Better Chunk Loading | May cause issues [[1]](https://github.com/FiniteReality/embeddium/wiki/Compatibility#other-known-incompatibilities) |
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
-| Chunk Sending | Redundant with Krypton/KryptonFNP |
+| Chunk Sending | Redundant with Krypton/KryptonReno |
 | CLab | AI-Slop. Redundant with Entity Culling |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Cull Leaves | Redundant with More Culling |
@@ -31,7 +31,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | FeyTweaks | Mostly redundant with ImmediatelyFast |
 | FPS Boost | Fake mod, doesn't provide any performance improvements |
 | GPUBooster/GPUTape | Doesn't actually fix VRAM leaks |
-| KryptonFoxified | Redundant with KryptonFNP |
+| KryptonFoxified | Redundant with KryptonReno |
 | Ksyxis | Removes spawn chunks |
 | lazy-language-loader | Redundant with Language Reload |
 | Methane | Disables light calculations, breaks Vanilla parity, incompatible with ScalableLux |
@@ -69,7 +69,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
 | Brute force render culling | Visual bugs |
 | Canary | Redundant with Radium |
-| Chunk Sending | Redundant with Krypton/KryptonFNP |
+| Chunk Sending | Redundant with Krypton/KryptonReno |
 | CLab | AI-Slop. Redundant with Entity Culling |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Concurrent Chunk Management Engine Forge (C2MEF) | No different than using C2ME via Synitra Connector |
@@ -133,7 +133,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
 | Brute force render culling | Visual bugs |
 | Canary | Redundant with Radium |
-| Chunk Sending | Redundant with Krypton/KryptonFNP |
+| Chunk Sending | Redundant with Krypton/KryptonReno |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Cull Clouds | Negligible performance improvement |
 | Cull Leaves | Redundant with More Culling |
@@ -164,7 +164,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | OptiLeaves | Redundant with CullLessLeaves Reforged |
 | OptiPainting | Redundant with FastPaintings |
 | Out Of Sight | Redundant with Entity Culling |
-| Pluto | Redundant with KryptonFNP |
+| Pluto | Redundant with KryptonReno |
 | Radon | Redundant with Starlight |
 | Recipe Essentials | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Redirector [Modern] | Compatibility issues, negligible performance improvement |
@@ -191,7 +191,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | Better Chunk Loading | May cause issues [[1]](https://github.com/FiniteReality/embeddium/wiki/Compatibility#other-known-incompatibilities) |
 | Better FPS - Render Distance | Might decrease fps on lower render distances, might cause visual bugs |
 | Brute force render culling | Visual bugs |
-| Chunk Sending | Redundant with Krypton/KryptonFNP |
+| Chunk Sending | Redundant with Krypton/KryptonReno |
 | Client Crafting | Mostly Redundant with FastFurnace, FastWorkbench and FastSuite |
 | Cull Clouds | Negligible performance improvement |
 | Cull Leaves | Redundant with More Culling |
@@ -218,7 +218,7 @@ This list assumes that you're already using every mod this guide recommends. Fur
 | OptiFine | [Various reasons](opti-not-so-fine.md) |
 | OptiLeaves | Redundant with CullLessLeaves Reforged |
 | Out Of Sight | Redundant with Entity Culling |
-| Pluto | Redundant with KryptonFNP |
+| Pluto | Redundant with KryptonReno |
 | Radon | Redundant with Starlight |
 | Recipe Cache | Redundant with FastFurnace, FastWorkench and FastSuite |
 | Redirector [Modern] | Compatibility issues, negligible performance improvement |


### PR DESCRIPTION
Per FNP's updated description: https://modrinth.com/mod/krypton-fnp

> Since we no longer provide Forge compatibility starting from version 26.1, the original name "Krypton FNP" is no longer meaningful.
> 
> The acronym "FNP" stood for "Forge and NeoForge's Port," but as Forge support is now absent, I have renamed this mod to Krypton Reno.
> 
> To ensure that our legacy URLs cannot be exploited by malicious parties, the URLs for our listings on Modrinth and CurseForge will remain unchanged, only the URL for the GitHub repository has been updated.